### PR TITLE
Added @Annotation to class doc comments of Annotation\Address + Annotation\Name

### DIFF
--- a/Mapping/Annotation/Address.php
+++ b/Mapping/Annotation/Address.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Annotations\Annotation;
 
 /**
  * Email address annotation.
- *
+ * @Annotation
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
 class Address extends Annotation

--- a/Mapping/Annotation/Name.php
+++ b/Mapping/Annotation/Name.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Annotations\Annotation;
 
 /**
  * Name annotation.
- *
+ * @Annotation
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
 class Name extends Annotation


### PR DESCRIPTION
Added @Annotation to class doc comments of Lexik\Bundle\MailerBundle\Mapping\Annotation\Address + Lexik\Bundle\MailerBundle\Mapping\Annotation\Name to avoid Sementical Error exceptions with Symfony 2.1
