### PR TITLE
Fix annotation capitalisation

### DIFF
--- a/Entity/EmailTranslation.php
+++ b/Entity/EmailTranslation.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @ORM\Entity
  * @ORM\Table(name="lexik_email_translation")
- * @ORM\HasLifeCycleCallbacks
+ * @ORM\HasLifecycleCallbacks
  *
  * @author Laurent Heurtault <l.heurtault@lexik.fr>
  * @author Cédric Girard <c.girard@lexik.fr>


### PR DESCRIPTION
This was causing the following error:
[Doctrine\Common\Annotations\AnnotationException]  
[Semantical Error] The annotation "@Doctrine\ORM\Mapping\HasLifeCycleCallbacks" in class Lexik\Bundle\MailerBundle\Entity\EmailTranslation does not exist, or could not be auto-loaded.
