### PR TITLE
Add an email form handler persistence setting

### DIFF
--- a/Form/Handler/EmailFormHandler.php
+++ b/Form/Handler/EmailFormHandler.php
@@ -38,6 +38,11 @@ class EmailFormHandler implements FormHandlerInterface
     private $locale;
 
     /**
+     * @var boolean
+     */
+    private $persist = true;
+
+    /**
      * @param FormFactoryInterface $factory
      * @param EntityManager        $em
      * @param string               $defaultLocale
@@ -93,12 +98,26 @@ class EmailFormHandler implements FormHandlerInterface
             $model = $form->getData();
             $model->getEntity()->addTranslation($model->getTranslation());
 
-            $this->em->persist($model->getEntity());
-            $this->em->flush();
+            if($this->getPersist()) {
+                $this->em->persist($model->getEntity());
+                $this->em->flush();
+            }
 
             $valid = true;
         }
 
         return $valid;
+    }
+    
+    public function getPersist()
+    {
+        return $this->persist;
+    }
+    
+    public function setPersist($persist)
+    {
+        $this->persist = (bool)$persist;
+        
+        return $this;
     }
 }


### PR DESCRIPTION
Sometimes I want to submit the form and check validity without persisting to the DB. This is backwards compatible but allows me to build live preview capabilities without requiring the system to persist the data in the database.