### PR TITLE
Use twig in from address

### DIFF
--- a/Entity/Email.php
+++ b/Entity/Email.php
@@ -348,11 +348,11 @@ class Email implements EmailInterface
     /**
      * @see Lexik\Bundle\MailerBundle\Model.EmailInterface::getFromAddress()
      */
-    public function getFromAddress($default)
+    public function getFromAddress()
     {
         $from = $this->currentTranslation->getFromAddress();
 
-        return !empty($from) ? $from : $default;
+        return $from;
     }
 
     /**

--- a/Message/MessageFactory.php
+++ b/Message/MessageFactory.php
@@ -264,6 +264,6 @@ class MessageFactory
             return $this->options['admin_email'];
         }
 
-        $this->renderTemplate('from_email', $parameters, $email->getChecksum());
+        $this->renderTemplate('from_address', $parameters, $email->getChecksum());
     }
 }

--- a/Message/MessageFactory.php
+++ b/Message/MessageFactory.php
@@ -264,6 +264,6 @@ class MessageFactory
             return $this->options['admin_email'];
         }
 
-        $this->renderTemplate('from_address', $parameters, $email->getChecksum());
+        return $this->renderTemplate('from_address', $parameters, $email->getChecksum());
     }
 }

--- a/Message/MessageFactory.php
+++ b/Message/MessageFactory.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\MailerBundle\Message;
 
+use Lexik\Bundle\MailerBundle\Entity\EmailTranslation;
 use Lexik\Bundle\MailerBundle\Model\EmailInterface;
 use Lexik\Bundle\MailerBundle\Mapping\Driver\Annotation;
 use Lexik\Bundle\MailerBundle\Exception\NoTranslationException;
@@ -145,7 +146,7 @@ class MessageFactory
 
             $message = $this->createMessageInstance()
                             ->setSubject($this->renderTemplate('subject', $parameters, $email->getChecksum()))
-                            ->setFrom($email->getFromAddress($this->options['admin_email']), $this->renderTemplate('from_name', $parameters, $email->getChecksum()))
+                            ->setFrom($this->renderFromAddress($email, $parameters), $this->renderTemplate('from_name', $parameters, $email->getChecksum()))
                             ->setTo($to)
                             ->setBody($this->renderTemplate('html_content', $parameters, $email->getChecksum()), 'text/html');
 
@@ -247,5 +248,22 @@ class MessageFactory
         }
 
         return $message;
+    }
+
+    /**
+     * Render email from address
+     *
+     * @param  EmailInterface $email
+     * @param  array          $parameters
+     *
+     * @return string
+     */
+    protected function renderFromAddress(EmailInterface $email, array $parameters = array())
+    {
+        if (null === $email->getFromAddress()) {
+            return $this->options['admin_email'];
+        }
+
+        $this->renderTemplate('from_email', $parameters, $email->getChecksum());
     }
 }

--- a/Model/EmailInterface.php
+++ b/Model/EmailInterface.php
@@ -55,11 +55,9 @@ interface EmailInterface
     /**
      * Returns the email address of the sender according to the email locale.
      *
-     * @param string $default
-     *
      * @return string
      */
-    public function getFromAddress($default);
+    public function getFromAddress();
 
     /**
      * Returns the name of the sender according to the email locale.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -61,6 +61,10 @@
             <call method="addExtension">
                 <argument type="service" id="twig.extension.routing" />
             </call>
+            <call method="addGlobal">
+                <argument>app</argument>
+                <argument type="service" id="templating.globals" />
+            </call>
         </service>
 
         <service id="lexik_mailer.message_renderer" class="%lexik_mailer.message_renderer.class%">

--- a/Twig/Loader/EmailLoader.php
+++ b/Twig/Loader/EmailLoader.php
@@ -49,8 +49,8 @@ class EmailLoader extends \Twig_Loader_Array
         $this->setTemplate(sprintf('html_content_%s', $emailSuffix), $content);
         $this->setTemplate(sprintf('text_content_%s', $emailSuffix), $email->getBodyText());
         $this->setTemplate(sprintf('subject_%s', $emailSuffix), $email->getSubject());
-        $this->setTemplate(sprintf('from_name_%s', $emailSuffix), $email->getFromAddress());
-        $this->setTemplate(sprintf('from_address_%s', $emailSuffix), $email->getFromName());
+        $this->setTemplate(sprintf('from_name_%s', $emailSuffix), $email->getFromName());
+        $this->setTemplate(sprintf('from_address_%s', $emailSuffix), $email->getFromAddress());
 
         // keep updated at to be able to check if the template is fresh
         $this->updateDates[sprintf('html_content_%s', $emailSuffix)] = $email->getLastModifiedTimestamp();

--- a/Twig/Loader/EmailLoader.php
+++ b/Twig/Loader/EmailLoader.php
@@ -50,12 +50,14 @@ class EmailLoader extends \Twig_Loader_Array
         $this->setTemplate(sprintf('text_content_%s', $emailSuffix), $email->getBodyText());
         $this->setTemplate(sprintf('subject_%s', $emailSuffix), $email->getSubject());
         $this->setTemplate(sprintf('from_name_%s', $emailSuffix), $email->getFromName());
+        $this->setTemplate(sprintf('from_address_%s', $emailSuffix), $email->getFromName());
 
         // keep updated at to be able to check if the template is fresh
         $this->updateDates[sprintf('html_content_%s', $emailSuffix)] = $email->getLastModifiedTimestamp();
         $this->updateDates[sprintf('text_content_%s', $emailSuffix)] = $email->getLastModifiedTimestamp();
         $this->updateDates[sprintf('subject_%s', $emailSuffix)] = $email->getLastModifiedTimestamp();
         $this->updateDates[sprintf('from_name_%s', $emailSuffix)] = $email->getLastModifiedTimestamp();
+        $this->updateDates[sprintf('from_address_%s', $emailSuffix)] = $email->getLastModifiedTimestamp();
     }
 
     /**

--- a/Twig/Loader/EmailLoader.php
+++ b/Twig/Loader/EmailLoader.php
@@ -49,7 +49,7 @@ class EmailLoader extends \Twig_Loader_Array
         $this->setTemplate(sprintf('html_content_%s', $emailSuffix), $content);
         $this->setTemplate(sprintf('text_content_%s', $emailSuffix), $email->getBodyText());
         $this->setTemplate(sprintf('subject_%s', $emailSuffix), $email->getSubject());
-        $this->setTemplate(sprintf('from_name_%s', $emailSuffix), $email->getFromName());
+        $this->setTemplate(sprintf('from_name_%s', $emailSuffix), $email->getFromAddress());
         $this->setTemplate(sprintf('from_address_%s', $emailSuffix), $email->getFromName());
 
         // keep updated at to be able to check if the template is fresh


### PR DESCRIPTION
Hello.

I needed to set the current connected user as mail sender. I saw you provided the way to use twig on from_name but not on from_email field so i suggest to add it on this PR. To achieve this, i've had the possibility to use the globals twig variables also.

I changed the getFromAddress signature cause we don't need default anymore but it's probably will be problematic as it will create a BC break. We can easily find a way to keep the same signature i think.

If you agree with this feature, we can add some testing if you want to. 
Just tell me :)