### PR TITLE
Add ErrorMessageInterface

### DIFF
--- a/Message/ErrorMessageInterface.php
+++ b/Message/ErrorMessageInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Lexik\Bundle\MailerBundle\Message;
+
+/**
+ * @author Nathanael d. Noblet <nathanael@noblet.ca>
+ */
+interface  ErrorMessageInterface
+{
+}

--- a/Message/NoTranslationMessage.php
+++ b/Message/NoTranslationMessage.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class NoTranslationMessage extends \Swift_Message
+class NoTranslationMessage extends \Swift_Message implements ErrorMessageInterface
 {
     /**
      * Construct

--- a/Message/ReferenceNotFoundMessage.php
+++ b/Message/ReferenceNotFoundMessage.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class ReferenceNotFoundMessage extends \Swift_Message
+class ReferenceNotFoundMessage extends \Swift_Message implements ErrorMessageInterface
 {
     /**
      * Construct.

--- a/Message/TwigErrorMessage.php
+++ b/Message/TwigErrorMessage.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class TwigErrorMessage extends \Swift_Message
+class TwigErrorMessage extends \Swift_Message implements ErrorMessageInterface
 {
     /**
      * Construct.

--- a/Message/UndefinedVariableMessage.php
+++ b/Message/UndefinedVariableMessage.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class UndefinedVariableMessage extends \Swift_Message
+class UndefinedVariableMessage extends \Swift_Message implements ErrorMessageInterface
 {
     /**
      * Construct.

--- a/Tests/Unit/Message/MessageFactoryTest.php
+++ b/Tests/Unit/Message/MessageFactoryTest.php
@@ -59,6 +59,7 @@ EOF;
 
         $message = $factory->get('this-reference-does-not-exixt', 'chuk@email.fr', array('name' => 'chuck'));
         $this->assertInstanceOf('Swift_Message', $message);
+        $this->assertInstanceOf('\Lexik\Bundle\MailerBundle\Message\ErrorMessageInterface', $message);
         $this->assertEquals(array('admin@email.fr' => null), $message->getTo());
         $this->assertEquals('An exception occurred', $message->getSubject());
         $this->assertEquals($body, $message->getBody());
@@ -73,6 +74,7 @@ EOF;
 
         $message = $factory->get('rabbids-template', 'chuk@email.fr', array('name' => 'chuck'), 'de');
         $this->assertInstanceOf('Swift_Message', $message);
+        $this->assertInstanceOf('\Lexik\Bundle\MailerBundle\Message\ErrorMessageInterface', $message);
         $this->assertEquals(array('admin@email.fr' => null), $message->getTo());
         $this->assertEquals('An exception occurred', $message->getSubject());
         $this->assertEquals($body, $message->getBody());
@@ -86,6 +88,7 @@ EOF;
 
         $message = $factory->get('rabbids-template', 'chuk@email.fr', array('name' => 'chuck'), 'es');
         $this->assertInstanceOf('Swift_Message', $message);
+        $this->assertInstanceOf('\Lexik\Bundle\MailerBundle\Message\ErrorMessageInterface', $message);
         $this->assertEquals(array('admin@email.fr' => null), $message->getTo());
         $this->assertEquals('An exception occurred', $message->getSubject());
         $this->assertEquals($body, $message->getBody());


### PR DESCRIPTION
To aid in detecting error messages, instead of using the class name
its simpler to test against an interface when an error occurs. This
adds an empty ErrorMessageInterface so that any error message returned
can be quickly tested without a switch statement if desired.