### PR TITLE
Avoid cc and bcc in error message mail

### DIFF
--- a/Message/ErrorMessage.php
+++ b/Message/ErrorMessage.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Lexik\Bundle\MailerBundle\Message;
+
+/**
+ * @author Yannick Snobbert <yannicksnobbert@gmail.com>
+ */
+class ErrorMessage extends \Swift_Message
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function addCc($address, $name = null)
+    {
+        //Avoid cc in error message mail
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setCc($addresses, $name = null)
+    {
+        //Avoid cc in error message mail
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addBcc($address, $name = null)
+    {
+        //Avoid bcc in error message mail
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setBcc($addresses, $name = null)
+    {
+        //Avoid bcc in error message mail
+    }
+}

--- a/Message/NoTranslationMessage.php
+++ b/Message/NoTranslationMessage.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class NoTranslationMessage extends \Swift_Message
+class NoTranslationMessage extends ErrorMessage
 {
     /**
      * Construct

--- a/Message/ReferenceNotFoundMessage.php
+++ b/Message/ReferenceNotFoundMessage.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class ReferenceNotFoundMessage extends \Swift_Message
+class ReferenceNotFoundMessage extends ErrorMessage
 {
     /**
      * Construct.

--- a/Message/TwigErrorMessage.php
+++ b/Message/TwigErrorMessage.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class TwigErrorMessage extends \Swift_Message
+class TwigErrorMessage extends ErrorMessage
 {
     /**
      * Construct.

--- a/Message/UndefinedVariableMessage.php
+++ b/Message/UndefinedVariableMessage.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 /**
  * @author Yoann Aparici <y.aparici@lexik.fr>
  */
-class UndefinedVariableMessage extends \Swift_Message
+class UndefinedVariableMessage extends ErrorMessage
 {
     /**
      * Construct.


### PR DESCRIPTION
On a production environment, my users received the error message. 
I purpose this fix i don't think we need multiple email for error messages? 