### PR TITLE
Do not display the sub translations admins on sonata dashboard

### DIFF
--- a/Resources/config/sonata.xml
+++ b/Resources/config/sonata.xml
@@ -33,7 +33,7 @@
             </call>
         </service>
         <service id="lexik_mailer.admin.layout_translation" class="%lexik_mailer.admin.layout_translation.class%">
-            <tag name="sonata.admin" manager_type="orm" group="Autre" label="Layouts Translations" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" label="Layouts Translations" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument/>
             <argument>Lexik\Bundle\MailerBundle\Entity\LayoutTranslation</argument>
             <argument></argument>
@@ -66,7 +66,7 @@
             </call>
         </service>
         <service id="lexik_mailer.admin.email_translation" class="%lexik_mailer.admin.email_translation.class%">
-            <tag name="sonata.admin" manager_type="orm" group="Autre" label="Emails Translations" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" label="Emails Translations" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument/>
             <argument>Lexik\Bundle\MailerBundle\Entity\EmailTranslation</argument>
             <argument></argument>


### PR DESCRIPTION
I made this simple pull request in response to issue #45 .