### PR TITLE
Sonata Admin Bundle inserted as required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "symfony/icu": ">=1.1",
         "swiftmailer/swiftmailer": ">=4.1.3",
         "doctrine/orm": "~2.2",
-        "twig/twig": ">=1.3.0"
+        "twig/twig": ">=1.3.0",
+        "sonata-project/admin-bundle": ">=2.3.3",
     },
     "autoload":     {
         "psr-0": { "Lexik\\Bundle\\MailerBundle": "" }


### PR DESCRIPTION
Sonata Admin Bundle inserted as required

[Symfony\Component\Debug\Exception\ClassNotFoundException]                  
Attempted to load class "Admin" from namespace "Sonata\AdminBundle\Admin".  
Did you forget a "use" statement for another namespace?