### PR TITLE
Added EmailDestinationInterface for getting recipients

### DIFF
--- a/Message/MessageFactory.php
+++ b/Message/MessageFactory.php
@@ -5,6 +5,7 @@ namespace Lexik\Bundle\MailerBundle\Message;
 use Doctrine\ORM\EntityManager;
 use Lexik\Bundle\MailerBundle\Exception\ReferenceNotFoundException;
 use Lexik\Bundle\MailerBundle\Model\EmailInterface;
+use Lexik\Bundle\MailerBundle\Model\EmailDestinationInterface;
 use Lexik\Bundle\MailerBundle\Mapping\Driver\Annotation;
 use Lexik\Bundle\MailerBundle\Exception\NoTranslationException;
 use Lexik\Bundle\MailerBundle\Message\ReferenceNotFoundMessage;
@@ -148,14 +149,8 @@ class MessageFactory
             $locale = $this->options['default_locale'];
         }
 
-        // Check for annotations
         if (is_object($to)) {
-            $name = $this->annotationDriver->getName($to);
-            $to = $this->annotationDriver->getEmail($to);
-
-            if (null !== $name && '' !== $name) {
-                $to = array($to => $name);
-            }
+            $to = $this->getRecipient($to);
         }
 
         try {
@@ -283,5 +278,26 @@ class MessageFactory
         }
 
         return $this->renderTemplate('from_address', $parameters, $email->getChecksum());
+    }
+
+    /**
+     * @param object $to
+     * @return array|string
+     */
+    protected function getRecipient($to)
+    {
+        if($to instanceof EmailDestinationInterface) {
+            $name = $to->getRecipientName();
+            $to = $to->getRecipientEmail();
+        } else {
+            $name = $this->annotationDriver->getName($to);
+            $to = $this->annotationDriver->getEmail($to);
+        }
+
+        if (null !== $name && '' !== $name) {
+            $to = array($to => $name);
+        }
+
+        return $to;
     }
 }

--- a/Model/EmailDestinationInterface.php
+++ b/Model/EmailDestinationInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lexik\Bundle\MailerBundle\Model;
+
+/**
+ * EmailDestinationInterface to be applied to user entities
+ *
+ */
+interface EmailDestinationInterface
+{
+    /**
+     * Returns the name of person email is destined for
+     *
+     * @return string
+     */
+    public function getRecipientName();
+
+    /**
+     * Returns the email address destination
+     *
+     * @return string
+     */
+    public function getRecipientEmail();
+}

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -160,7 +160,7 @@ $container->get('mailer')->send($message);
 ```
     
     
-Use annotations to make the `lexik_mailer.message_factory` service automaticaly get the name and the email address of the recipient:
+Use annotations or implement the `EmailDestinationInterface` to make the `lexik_mailer.message_factory` service automaticaly get the name and the email address of the recipient:
 
 ```php
 <?php
@@ -193,6 +193,35 @@ class User
     }
 }
 ```
+
+```php
+<?php
+// SomeBundle/Entity/User.php
+//...
+use Lexik\Bundle\MailerBundle\Model\EmailDestinationInterface;
+
+class User implements EmailDestinationInterface
+{
+    //...
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+        
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+}
+```
+
 Override Controllers:
 ---------------------
 

--- a/Tests/Unit/Entity/UserTest.php
+++ b/Tests/Unit/Entity/UserTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lexik\Bundle\MailerBundle\Tests\Entity;
+
+use Lexik\Bundle\MailerBundle\Model\EmailDestinationInterface;
+
+class UserTest implements EmailDestinationInterface
+{
+    public function getRecipientName()
+    {
+        return 'User';
+    }
+
+    public function getRecipientEmail()
+    {
+        return 'user@example.net';
+    }
+}

--- a/Tests/Unit/Message/MessageFactoryTest.php
+++ b/Tests/Unit/Message/MessageFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\MailerBundle\Tests\Message;
 
 use Lexik\Bundle\MailerBundle\Exception\ReferenceNotFoundException;
+use Lexik\Bundle\MailerBundle\Tests\Entity\UserTest;
 use Lexik\Bundle\MailerBundle\Twig\Loader\EmailLoader;
 use Lexik\Bundle\MailerBundle\Message\MessageRenderer;
 use Lexik\Bundle\MailerBundle\Message\MessageFactory;
@@ -54,7 +55,7 @@ class MessageFactoryTest extends BaseUnitTestCase
         $body = <<<EOF
 An error occurred while trying to send an email.
 You tried to use a reference that does not exist : "this-reference-does-not-exist"
-in "{$file}" at line 60
+in "{$file}" at line 61
 EOF;
 
         $message = $factory->get('this-reference-does-not-exist', 'chuk@email.fr', array('name' => 'chuck'));
@@ -140,5 +141,18 @@ EOF;
         $this->setExpectedException('Lexik\Bundle\MailerBundle\Exception\ReferenceNotFoundException');
         $factory = $this->createMessageFactory();
         $factory->getEmail('this-reference-does-not-exist');
+    }
+
+    public function testGetRecipient()
+    {
+        $factory = $this->createMessageFactory();
+
+        $class = new \ReflectionClass($factory);
+        $method = $class->getMethod('getRecipient');
+        $method->setAccessible(true);
+
+        $user = new UserTest();
+        $recipient = $method->invokeArgs($factory,array($user));
+        $this->assertEquals(array('user@example.net'=>'User'),$recipient);
     }
 }


### PR DESCRIPTION
We recently refactored a project and as part of the refactoring had an AbstractUser class. The annotations didn't seem to be picked up so the mail was silently failing to send. This allows people to use an interface instead of annotations which can also be faster to check.