### PR TITLE
fixed `Twig_Environment` class name

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -55,7 +55,7 @@
         </service>
 
         <!-- Template -->
-        <service id="lexik_mailer.templating" class="Twig_Environnement" public="false" >
+        <service id="lexik_mailer.templating" class="Twig_Environment" public="false" >
             <argument type="service" id="lexik_mailer.templating.loader_chain" />
             <argument>%lexik_mailer.templating.default_options%</argument>
             <call method="addExtension">


### PR DESCRIPTION
```
Attempted to load class "Twig_Environnement" from the global namespace.
Did you forget a "use" statement?
```