### PR TITLE
Change ORM\GeneratedValue strategy for Oracle compatibility

### DIFF
--- a/Entity/Email.php
+++ b/Entity/Email.php
@@ -27,7 +27,7 @@ class Email implements EmailInterface
      *
      * @ORM\Id
      * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 

--- a/Entity/Layout.php
+++ b/Entity/Layout.php
@@ -26,7 +26,7 @@ class Layout implements LayoutInterface
      *
      * @ORM\Id
      * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;
 


### PR DESCRIPTION
Change ORM\GeneratedValue strategy for Oracle compatibility
Strategy INDENTITY don't work with Oracle. Use AUTO

Docs: 
http://docs.doctrine-project.org/en/latest/reference/basic-mapping.html#identifier-generation-strategies