### PR TITLE
Twig 2.x deprecated interfaces Twig_ExistsLoaderInterface , Twig_SourceContextLoaderInterface 

### DIFF
--- a/Twig/Loader/EmailLoader.php
+++ b/Twig/Loader/EmailLoader.php
@@ -9,7 +9,7 @@ use Lexik\Bundle\MailerBundle\Model\EmailInterface;
  *
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class EmailLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface, \  Twig_SourceContextLoaderInterface
+class EmailLoader implements \Twig_LoaderInterface 
 {
     /**
      * @var array


### PR DESCRIPTION
As of Twig 2.x, the following interfaces are deprecated and empty (th…ey will be removed in Twig 3.0):

- Twig_ExistsLoaderInterface (merged with Twig_LoaderInterface)
- Twig_SourceContextLoaderInterface (merged with Twig_LoaderInterface)

https://twig.symfony.com/doc/1.x/deprecated.html#loaders